### PR TITLE
Display response in the markup using

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,9 +1,19 @@
 <?php
 error_reporting(E_ALL); 
+$_SESSION ?? session_start(); 
+
+use SessionSync\SabreRestAPIDB; 
 
 require_once('vendor/autoload.php'); 
 require_once('src/SabreRestAPI.php'); 
+require_once('src/SabreRestAPIDB.php'); 
+require_once('RequestModel.php'); 
 
+
+if($_GET['response'] ?? false) { 
+    $SabreAPI = new \SessionSync\SabreRestAPI(); 
+    $request = $SabreAPI->fetch_hotel('POST' , $hotel_avail_route , $request_json); 
+} 
 
 /**
  * to use the client side commuinication with 

--- a/template.php
+++ b/template.php
@@ -3,11 +3,42 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Sabre Session Management</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha1/css/bootstrap.min.css" integrity="sha384-r4NyP46KrjDleawBgD5tp8Y7UzmLA05oM1iAEQ17CSuDqnUK2+k9luXQOfXJCJ4I" crossorigin="anonymous">
 </head>
 <body>
-    <h1>Welcome</h1>
 
+    <div class="container">
+        <h1>
+            Session Management
+        </h1>
+        <h3>Sample of request </h3>
+        <hr />
+        <div class="overflow-auto bg-light mb-2" style="height: 300px;">
+            <code>
+              <pre>  
+                    <?php print_r($request_json); ?> 
+              </pre>
+            </code>
+        </div>
+
+
+        <a class="btn btn-primary btn-large" href="index.php?response=do">get the response  </a>
+
+        <?php if($_GET['response'] ?? false): ?> 
+        <h3>Sample of Response </h3>
+        <hr />
+        <div class="overflow-auto bg-light" style="height: 300px;">
+            <code>
+              <pre>  
+                    <?php print_r(json_decode($request->getBody()->getContents(),true)); ?> 
+              </pre>
+            </code>
+        </div>
+        <?php endif; ?> 
+
+        
+    </div>
 
     <script>
         var conn = new WebSocket('ws://localhost:8080');


### PR DESCRIPTION
Display Sabre response in the markup by using `$_GET` to start the request. 
__note__ this is just to trigger the API not recommended for real application usage.
![Sabre-response](https://user-images.githubusercontent.com/60617324/88447091-ac2bc580-ce40-11ea-85f5-4f8a87e93da1.png)
